### PR TITLE
Run fixfiles for howler-rsyslog

### DIFF
--- a/howler.spec
+++ b/howler.spec
@@ -6,7 +6,7 @@
 
 Name:       python-howler
 Version:    0.2
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Alert when users log in from new locations
 
 License:    GPLv3+
@@ -82,6 +82,12 @@ do
 done
 /usr/sbin/hardlink -cv %{buildroot}%{_datadir}/selinux
 
+%post -n howler-rsyslog
+/sbin/fixfiles -R howler-rsyslog restore || :
+
+%postun -n howler-rsyslog
+/sbin/fixfiles -R howler-rsyslog restore %{fixfiles_dirs} || :
+
 %post -n howler-selinux
 for selinuxvariant in %{selinux_variants}
 do
@@ -121,6 +127,9 @@ fi
 
 
 %changelog
+* Sun Jun 16 2013 Rene Cunningham <rene@linuxfoundation.org>
+- Run fixfiles for howler-rsyslog.
+
 * Thu Nov 08 2012 Konstantin Ryabitsev <mricon@kernel.org>
 - Update to 0.2 and split into subpackages.
 - Add selinux subpackage.


### PR DESCRIPTION
Without this selinux context for /usr/bin/howler-syslog-helper is

```
system_u:object_r:bin_t:s0
```

which generates this AVC

```
type=AVC msg=audit(1371376156.209:36058): avc:  denied  { search } for  pid=7391 comm="howler-syslog-h" name="howler" dev=dm-0 ino=299263 scontext=unconfined_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:howler_var_lib_t:s0 tclass=dir
```
